### PR TITLE
gpu-op: workaround collector.unready

### DIFF
--- a/charms/gpu-operator/src/charm.py
+++ b/charms/gpu-operator/src/charm.py
@@ -54,8 +54,15 @@ class GPUOperatorCharm(CharmBase):
             return
         self.unit.status = MaintenanceStatus("Updating Status")
 
-        unready = self.collector.unready
+        conditions = self.collector.conditions
+        # FIXME: workaround collector.unready because one of the gpu-operator conditions is 'Error'
+        unready = sorted(
+            f"{name}: {obj} is not {cond.type}"
+            for (name, obj), cond in conditions.items()
+            if cond.status != "True" and cond.type != "Error"
+        )
         current_ns, config_ns = self.stored.namespace, self._configured_ns
+
         if unready:
             self.unit.status = WaitingStatus(", ".join(unready))
         elif current_ns != config_ns:


### PR DESCRIPTION
[LP:2053175](https://bugs.launchpad.net/nvidia-operators/+bug/2053175)

The gpu operator has a `cluster-policy` condition of type Error and status False:
```
Status:
  Conditions:
    Last Transition Time:  2024-02-14T13:27:37Z
    Message:               ClusterPolicy is ready as all resources have been successfully reconciled
    Reason:                Reconciled
    Status:                True
    Type:                  Ready
    Last Transition Time:  2024-02-14T13:27:37Z
    Message:               
    Reason:                Ready
    Status:                False
    Type:                  Error
```
That translates to "I'm in error?  No!" which is a long way to say that everything is ok.  Unfortunately, our collector thinks anything without `status: True` [is unready](https://github.com/canonical/ops-lib-manifest/blob/main/ops/manifests/collector.py#L88-L94).

Ideally charms would be able to pass a filter to the (un)readiness check that would allow us to filter what constitutes an unready condition.

Until that ability lands in `ops.lib.manifests`, we can workaround it.  This PR does that.